### PR TITLE
changes capitalisation on the SelectItems in the SelectCmDevice query

### DIFF
--- a/risport70_selectCmDevice.py
+++ b/risport70_selectCmDevice.py
@@ -103,14 +103,14 @@ criteria = {
     'Protocol': 'Any',  
     'DownloadStatus': 'Any', 
     'SelectItems': {
-        'Item': [ ]
+        'item': [ ]
     } 
 }
 
 # One or more specific devices can be retrieved by replacing * with
 # the device name in multiple items
-criteria['SelectItems']['Item'].append(
-    { 'item': '*'}
+criteria['SelectItems']['item'].append(
+    { 'Item': '*'}
 )
 
 # Execute the request


### PR DESCRIPTION
Looking at the [docs](https://developer.cisco.com/docs/sxml/#!risport70-api-reference/selectcmdevice) it seems that capitalisation of the items in the SelectItems element is the inverse of what it is in this example code. As the code is currently written all items (or 1000, whichever is less) are returned from the Risport even if items are specified in the SelectItems dict. With this change items in the SelectItems element are the only ones returned from the Risport. 